### PR TITLE
Fixed bug where social media URL wont work on loading a save

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -389,8 +389,10 @@ if (localStorage.getItem("names") !== null) {
   console.log("Found saved data, loading...");
   var savedURL = localStorage.getItem("url");
 
-  $("#st-1").attr("data-url", savedURL);
-  console.log("setting st-1 to " + savedURL);
+  setTimeout(function() {
+    $("#st-1").attr("data-url", savedURL);
+    console.log("setting st-1 to " + savedURL);
+  }, 1000);
 
   usedSavedRoute();
   $("#route-link").show();


### PR DESCRIPTION
Fixed bug where Social Media sharing buttons will not work on loading a saved URL from local storage. This was done by adding a timeout of 1 second to change the "data-val" attribute of the buttons to give them time to load, as they are dynamically loaded and not instantly rendered on the page.